### PR TITLE
New test workflows and support

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
   build_and_upload_wheel:
     name: Build and upload wheel
     container:
-      image: ghcr.io/oxionics/poetry:1.3
+      image: ghcr.io/oxionics/poetry:v1.5
     runs-on: self-hosted
     steps:
       - name: Checkout
@@ -22,16 +22,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Poetry dynamic versioning
+        run: $POETRY_PIP install poetry-dynamic-versioning==0.13.1
+
       - name: Build wheel
-        run: poetry build -f wheel
+        run: $POETRY build -f wheel
 
       - name: Configure poetry
         if: github.event_name == 'push'
         run: |
-          poetry config repositories.oxionics ${{ secrets.PYPI_SERVER }}
-          poetry config http-basic.oxionics \
+          $POETRY config repositories.oxionics ${{ secrets.PYPI_SERVER }}
+          $POETRY config http-basic.oxionics \
             ${{ secrets.PYPI_LOGIN }} ${{ secrets.PYPI_PASSWORD }}
 
       - name: Upload wheel
         if: github.event_name == 'push'
-        run: poetry publish -r oxionics
+        run: $POETRY publish -r oxionics

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Package
+
+on:
+  workflow_call:
+    inputs:
+      TEST_PATH:
+        required: false
+        default: .
+        type: string
+      INSTALL_ARGS:
+        required: false
+        type: string
+
+
+
+jobs:
+  test:
+    runs-on: self-hosted
+    container: ghcr.io/oxionics/poetry:v1.5
+    name: Unit Tests
+    steps:
+      - uses: OxIonics/poetry-preamble@master
+        with:
+          INSTALL_ARGS: ${{ inputs.INSTALL_ARGS }}
+          GHA_TOKEN: ${{ secrets.GHA_TOKEN }}
+
+      - name: Test
+        run: $POETRY run pytest -v ${{ inputs.TEST_PATH }}

--- a/.github/workflows/test_flake_yapf.yml
+++ b/.github/workflows/test_flake_yapf.yml
@@ -1,0 +1,55 @@
+on:
+  workflow_call:
+    inputs:
+      TEST_PATH:
+        required: false
+        default: .
+        type: string
+      INSTALL_ARGS:
+        required: false
+        type: string
+      PACKAGE_NAME:
+        required: true
+        type: string
+
+jobs:
+  # we can't reuse the sibling test workflow here because we're limited to a
+  # workflow depth of 2.
+  test:
+    runs-on: self-hosted
+    container: ghcr.io/oxionics/poetry:v1.5
+    name: Unit Tests
+    steps:
+      - uses: OxIonics/poetry-preamble@master
+        with:
+          INSTALL_ARGS: ${{ inputs.INSTALL_ARGS }}
+          GHA_TOKEN: ${{ secrets.GHA_TOKEN }}
+
+      - name: Test
+        run: $POETRY run pytest -v ${{ inputs.TEST_PATH }}
+
+  flake8:
+    runs-on: self-hosted
+    container: ghcr.io/oxionics/poetry:v1.5
+    name: Flake8
+    steps:
+      - uses: OxIonics/poetry-preamble@master
+        with:
+          INSTALL_ARGS: ${{ inputs.INSTALL_ARGS }}
+          GHA_TOKEN: ${{ secrets.GHA_TOKEN }}
+
+      - name: Flake8
+        run: $POETRY run flake8 ${{ inputs.PACKAGE_NAME }}
+
+  yapf:
+    runs-on: self-hosted
+    container: ghcr.io/oxionics/poetry:v1.5
+    name: Yapf
+    steps:
+      - uses: OxIonics/poetry-preamble@master
+        with:
+          INSTALL_ARGS: ${{ inputs.INSTALL_ARGS }}
+          GHA_TOKEN: ${{ secrets.GHA_TOKEN }}
+
+      - name: Yapf
+        run: $POETRY run yapf -d -r ${{ inputs.PACKAGE_NAME }}


### PR DESCRIPTION
There's a new poetry image with out dynamic versioning and with
poetry installed in a venv so that we can install dynamic versioning
in to that venv when needed.
There's composite action at OxIonics/poetry-preamble for us to put
poetry setup stuff in.
There's test.yml workflow for running just the tests and a
test_flake_yapf.yml workflow for running all 3 of them.