### PR TITLE
Fix scheduled build binaries

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build Binaries
         run: |
-          export PATH=${{ secrets.VIVADO_ROOT_DIR }}/${{ inputs.vivado_version }}/bin/:$PATH
+          export PATH=${{ secrets.VIVADO_ROOT_DIR }}/${{ inputs.vivado_version || '2020.1' }}/bin/:$PATH
           poetry run binary_build \
             --gh-user oxionics \
             --gh-password ${{ secrets.GHA_TOKEN }} \


### PR DESCRIPTION
You can't get inputs in schedules, so where ever build binaries is
invoked from a schedule it would have to find another value for
vivado_version. This will hopefully mean that the vivado_version is
defaulted to 2020.1 if it's not set, so that schedules will run
correctly.

-----

Not sure how to test this with out merging it.

\cc @lochsh 