### PR TITLE
Try adding option for uploading package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,6 +14,12 @@ on:
         required: false
         default: ""
         type: string
+  workflow_dispatch:
+    inputs:
+      upload:
+        type: boolean
+        description: Upload package
+        default: false
 
 jobs:
   build_and_upload_wheel:
@@ -35,12 +41,12 @@ jobs:
         run: $POETRY build -f wheel
 
       - name: Configure poetry
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' ||  ${{ github.event.inputs.upload  == 'true' }}
         run: |
           $POETRY config repositories.oxionics ${{ secrets.PYPI_SERVER }}
           $POETRY config http-basic.oxionics \
             ${{ secrets.PYPI_LOGIN }} ${{ secrets.PYPI_PASSWORD }}
 
       - name: Upload wheel
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' ||  ${{ github.event.inputs.upload  == 'true' }}
         run: $POETRY publish -r oxionics


### PR DESCRIPTION
When testing this on ion-transport https://github.com/OxIonics/ion-transport/runs/6755688650?check_suite_focus=true, we didn't get an option for whether to enable the wheel upload.

We think this might just be because the master branch of ion-transport isn't using this branch of common-workflows, so we think it makes sense to merge this and see if that is the case.

cc @SquidDev 