### PR TITLE
Revert "Try adding option for uploading package"

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,12 +14,6 @@ on:
         required: false
         default: ""
         type: string
-  workflow_dispatch:
-    inputs:
-      upload:
-        type: boolean
-        description: Upload package
-        default: false
 
 jobs:
   build_and_upload_wheel:
@@ -41,12 +35,12 @@ jobs:
         run: $POETRY build -f wheel
 
       - name: Configure poetry
-        if: github.event_name == 'push' ||  ${{ github.event.inputs.upload  == 'true' }}
+        if: github.event_name == 'push'
         run: |
           $POETRY config repositories.oxionics ${{ secrets.PYPI_SERVER }}
           $POETRY config http-basic.oxionics \
             ${{ secrets.PYPI_LOGIN }} ${{ secrets.PYPI_PASSWORD }}
 
       - name: Upload wheel
-        if: github.event_name == 'push' ||  ${{ github.event.inputs.upload  == 'true' }}
+        if: github.event_name == 'push'
         run: $POETRY publish -r oxionics


### PR DESCRIPTION
Reverts OxIonics/common-workflows#10

When this is used from repositories (like ion-transport), it's always a workflow_call. So the options we added for workflow_dispatch are not useful.