### PR TITLE
Use v1.15 of poetry image, to get rust toolchain

### DIFF
--- a/.github/workflows/common_pre_commit_checks.yml
+++ b/.github/workflows/common_pre_commit_checks.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   check:
     runs-on: self-hosted
-    container: ghcr.io/oxionics/poetry:1.12
+    container: ghcr.io/oxionics/poetry:1.15
     name: Common pre-commit checks
     steps:
       - uses: OxIonics/poetry-preamble@master

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -23,7 +23,7 @@ jobs:
   build_and_upload_wheel:
     name: Build and upload wheel
     container:
-      image: ghcr.io/oxionics/poetry:1.12
+      image: ghcr.io/oxionics/poetry:1.15
     runs-on: self-hosted
     steps:
       - name: Checkout

--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   pytype:
     runs-on: self-hosted
-    container: ghcr.io/oxionics/poetry:1.12
+    container: ghcr.io/oxionics/poetry:1.15
     steps:
       - uses: OxIonics/poetry-preamble@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   test:
     runs-on: self-hosted
-    container: ghcr.io/oxionics/poetry:1.12
+    container: ghcr.io/oxionics/poetry:1.15
     name: Unit Tests
     steps:
       - uses: OxIonics/poetry-preamble@master

--- a/.github/workflows/test_flake_black.yml
+++ b/.github/workflows/test_flake_black.yml
@@ -25,7 +25,7 @@ jobs:
   test:
     if: ${{ inputs.RUN_TESTS }}
     runs-on: self-hosted
-    container: ghcr.io/oxionics/poetry:1.12
+    container: ghcr.io/oxionics/poetry:1.15
     name: Unit Tests
     steps:
       - uses: OxIonics/poetry-preamble@master
@@ -38,7 +38,7 @@ jobs:
 
   flake8:
     runs-on: self-hosted
-    container: ghcr.io/oxionics/poetry:1.12
+    container: ghcr.io/oxionics/poetry:1.15
     name: Flake8
     steps:
       - uses: OxIonics/poetry-preamble@master
@@ -51,7 +51,7 @@ jobs:
 
   black:
     runs-on: self-hosted
-    container: ghcr.io/oxionics/poetry:1.12
+    container: ghcr.io/oxionics/poetry:1.15
     name: Formatting check
     steps:
       - uses: OxIonics/poetry-preamble@master

--- a/.github/workflows/test_flake_yapf.yml
+++ b/.github/workflows/test_flake_yapf.yml
@@ -20,7 +20,7 @@ jobs:
   # workflow depth of 2.
   test:
     runs-on: self-hosted
-    container: ghcr.io/oxionics/poetry:1.12
+    container: ghcr.io/oxionics/poetry:1.15
     name: Unit Tests
     steps:
       - uses: OxIonics/poetry-preamble@master
@@ -33,7 +33,7 @@ jobs:
 
   flake8:
     runs-on: self-hosted
-    container: ghcr.io/oxionics/poetry:1.12
+    container: ghcr.io/oxionics/poetry:1.15
     name: Flake8
     steps:
       - uses: OxIonics/poetry-preamble@master
@@ -46,7 +46,7 @@ jobs:
 
   yapf:
     runs-on: self-hosted
-    container: ghcr.io/oxionics/poetry:1.12
+    container: ghcr.io/oxionics/poetry:1.15
     name: Yapf
     steps:
       - uses: OxIonics/poetry-preamble@master


### PR DESCRIPTION
This is needed for the new poetry-preamble which checks for maturin
being installed in the poetry env, and then builds the crate using PyO3
if it is found.