### PR TITLE
Update GitHub actions to use NodeJS 16

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
@@ -53,4 +53,3 @@ jobs:
             ${{ github.workspace }} \
             ${{ inputs.config_module }} \
             binaries
-

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1

--- a/.github/workflows/package-windows-macos.yml
+++ b/.github/workflows/package-windows-macos.yml
@@ -25,13 +25,13 @@ jobs:
           uses: windows-2022
           extra-target: ""
         - name: MacOS
-          uses: macos-10.15
+          uses: macos-11
           extra-target: aarch64-apple-darwin
 
     runs-on: ${{ matrix.uses }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive
@@ -72,7 +72,7 @@ jobs:
       - name: Build wheel
         run: poetry build -f wheel
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: wheel-${{ matrix.uses }}
           path: ./dist/*whl
@@ -85,11 +85,11 @@ jobs:
     container: ghcr.io/oxionics/poetry:1.17
     runs-on: self-hosted
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           path: ./artifacts
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: recursive


### PR DESCRIPTION
The @2 versions used NodeJS 12, which is now deprecated. This silences several warnings during our builds. While there is a major version bump, this does not include any breaking changes.
