### PR TITLE
Set Ubuntu version on multiplatform to 20.04

### DIFF
--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -26,7 +26,9 @@ jobs:
       matrix:
         include:
         - name: Linux
-          uses: ubuntu-latest
+          # The version of Ubuntu implicitly controls the version of glibc 
+          # required by any resulting wheels.
+          uses: ubuntu-20.04
           extra-target: ""
         - name: Windows
           uses: windows-2022


### PR DESCRIPTION
This ensures that we build wheels with an older glibc dependency so that they can be installed on 20.04 targets.

See also: https://oxionics.slack.com/archives/C02TBJJNC3U/p1687882919350319