### PR TITLE
docker-publish: allow calling workflow to inject a command to prep Dockerfile

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,10 @@ on:
         required: false
         type: string
         default: ""
+      PREPARE_COMMAND:
+        required: true
+        type: string
+        default: "true"
 
 jobs:
   push:
@@ -24,6 +28,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Make preparations
+        run: ${{ inputs.PREPARE_COMMAND }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1


### PR DESCRIPTION
This is useful for https://github.com/OxIonics/poetry-image/pull/15 so we don't have to ship two nearly identical Dockerfiles but can run a quick shell script to apply a template parameter.
