### PR TITLE
docker-publish: fix clash of temporary image name when using TAG_SUFFIX

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build image
         run: |
           set -x
-          docker build . --tag ${{ inputs.IMAGE_NAME}}:$GITHUB_RUN_NUMBER ${{ inputs.BUILD_ARGS }}
+          docker build . --tag ${{ inputs.IMAGE_NAME}}:$GITHUB_RUN_NUMBER${{ inputs.TAG_SUFFIX }} ${{ inputs.BUILD_ARGS }}
 
       - name: Push image to GitHub Container Registry
         if: github.event_name == 'push'
@@ -55,7 +55,7 @@ jobs:
           echo VERSION=$VERSION
           TAG="$VERSION${{ inputs.TAG_SUFFIX }}"
           echo TAG=$TAG
-          docker tag $IMAGE_NAME:$GITHUB_RUN_NUMBER $IMAGE_ID:$TAG
+          docker tag $IMAGE_NAME:$GITHUB_RUN_NUMBER${{ inputs.TAG_SUFFIX }} $IMAGE_ID:$TAG
           docker push $IMAGE_ID:$TAG
 
       - name: Clean up image

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build image
         run: |
           set -x
-          docker build . --iidfile image_id --tag ${{ inputs.IMAGE_NAME}}:$GITHUB_RUN_NUMBER${{ inputs.TAG_SUFFIX }} ${{ inputs.BUILD_ARGS }}
+          docker build . --iidfile image_id --tag ${{ inputs.IMAGE_NAME }}:$GITHUB_RUN_NUMBER${{ inputs.TAG_SUFFIX }} ${{ inputs.BUILD_ARGS }}
 
       - name: Push image to GitHub Container Registry
         if: github.event_name == 'push'
@@ -59,4 +59,4 @@ jobs:
           docker push $IMAGE_ID:$TAG
 
       - name: Clean up image
-        run: docker image rm ${{ inputs.IMAGE_NAME }}:$GITHUB_RUN_NUMBER
+        run: docker image rm "$(cat image_id)"

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build image
         run: |
           set -x
-          docker build . --tag ${{ inputs.IMAGE_NAME}}:$GITHUB_RUN_NUMBER${{ inputs.TAG_SUFFIX }} ${{ inputs.BUILD_ARGS }}
+          docker build . --iidfile image_id --tag ${{ inputs.IMAGE_NAME}}:$GITHUB_RUN_NUMBER${{ inputs.TAG_SUFFIX }} ${{ inputs.BUILD_ARGS }}
 
       - name: Push image to GitHub Container Registry
         if: github.event_name == 'push'
@@ -55,7 +55,7 @@ jobs:
           echo VERSION=$VERSION
           TAG="$VERSION${{ inputs.TAG_SUFFIX }}"
           echo TAG=$TAG
-          docker tag $IMAGE_NAME:$GITHUB_RUN_NUMBER${{ inputs.TAG_SUFFIX }} $IMAGE_ID:$TAG
+          docker tag "$(cat image_id)" $IMAGE_ID:$TAG
           docker push $IMAGE_ID:$TAG
 
       - name: Clean up image


### PR DESCRIPTION
When we use TAG_SUFFIX to build multiple images, we call the docker-publish workflow multiple times, in which case it must use different names for the temporary images.
