### PR TITLE
Fix image clean-up

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Build image
         run: |
           set -x
-          docker build . --iidfile image_id --tag ${{ inputs.IMAGE_NAME }}:$GITHUB_RUN_NUMBER${{ inputs.TAG_SUFFIX }} ${{ inputs.BUILD_ARGS }}
+          docker build . --iidfile image_id ${{ inputs.BUILD_ARGS }}
+          docker tag "$(cat image_id)" ${{ inputs.IMAGE_NAME }}:"$(cat image_id)"
 
       - name: Push image to GitHub Container Registry
         if: github.event_name == 'push'
@@ -59,4 +60,4 @@ jobs:
           docker push $IMAGE_ID:$TAG
 
       - name: Clean up image
-        run: docker image rm "$(cat image_id)"
+        run: docker image rm ${{ inputs.IMAGE_NAME }}:"$(cat image_id)"


### PR DESCRIPTION
We want to tag the image at the beginning and remove that tag at the end. If the image was not tagged with another tag (which we do if triggered by a push), this removes the image itself, too.
But we want a reliably unique tag as the temporary tag name. Using the build id alone is not necessarily unique, because some workflows call this workflow multiple times.
The image id generated by Docker is unique - so let's use that to construct a temporary tag name.
