### PR TITLE
Fix "Fix image clean-up (#52)"

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,8 +35,7 @@ jobs:
       - name: Build image
         run: |
           set -x
-          docker build . --iidfile image_id ${{ inputs.BUILD_ARGS }}
-          docker tag "$(cat image_id)" ${{ inputs.IMAGE_NAME }}:"$(cat image_id)"
+          docker build . --iidfile image_id --tag ${{ inputs.IMAGE_NAME }}:$GITHUB_RUN_NUMBER${{ inputs.TAG_SUFFIX }} ${{ inputs.BUILD_ARGS }}
 
       - name: Push image to GitHub Container Registry
         if: github.event_name == 'push'
@@ -60,4 +59,4 @@ jobs:
           docker push $IMAGE_ID:$TAG
 
       - name: Clean up image
-        run: docker image rm ${{ inputs.IMAGE_NAME }}:"$(cat image_id)"
+        run: docker image rm ${{ inputs.IMAGE_NAME }}:$GITHUB_RUN_NUMBER${{ inputs.TAG_SUFFIX }}


### PR DESCRIPTION
That PR broke more things then it fixed. The contents of the `image_id` file are unsuitable as a tag name (contains a colon). So let's revert to GitHub run number plus TAG_SUFFIX. This *should* be unique.
