### PR TITLE
Don't log into container registry from multiple jobs in parallel

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,8 +24,8 @@ jobs:
 
     concurrency:
       # If triggered by a push, we will upload the image to the container
-      # registry. Logging in/out of the registry seems in parallel running
-      # jobs seems to interfere with each other.
+      # registry. Logging in/out of the registry from jobs running in parallel
+      # seems to interfere with each other.
       group: "${{ github.event_name == 'push' && 'ghcr-login' || null }}"
 
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,20 +22,27 @@ jobs:
       group: Default
       labels: self-hosted
 
+    concurrency:
+      # If triggered by a push, we will upload the image to the container
+      # registry. Logging in/out of the registry seems in parallel running
+      # jobs seems to interfere with each other.
+      group: "${{ github.event_name == 'push' && 'ghcr-login' || null }}"
+
     steps:
       - uses: actions/checkout@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build image
         run: |
           set -x
           docker build . --iidfile image_id --tag ${{ inputs.IMAGE_NAME }}:$GITHUB_RUN_NUMBER${{ inputs.TAG_SUFFIX }} ${{ inputs.BUILD_ARGS }}
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name == 'push'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push image to GitHub Container Registry
         if: github.event_name == 'push'


### PR DESCRIPTION
The `docker/login-action` automatically adds a log out step at the end of the job.
Sadly, this seems to also affect any other job that runs in parallel and has logged into the registry.
We only need to log in when we intend to push an image to the registry, so in those cases we can set a concurrency group to avoid running this job multiple times in parallel.
