### PR TITLE
Update version of our poetry build image

### DIFF
--- a/.github/workflows/common_pre_commit_checks.yml
+++ b/.github/workflows/common_pre_commit_checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on:
       group: Default
       labels: self-hosted
-    container: ghcr.io/oxionics/poetry:1.21
+    container: ghcr.io/oxionics/poetry:1.22-py3.8
     name: Common pre-commit checks
     steps:
       - uses: OxIonics/poetry-preamble@master

--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -125,7 +125,7 @@ jobs:
   upload_wheels:
     needs: build_wheels
     if: github.event_name == 'push'
-    container: ghcr.io/oxionics/poetry:1.21
+    container: ghcr.io/oxionics/poetry:1.22-py3.8
     runs-on:
       group: Default
       labels: self-hosted

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -23,7 +23,7 @@ jobs:
   build_and_upload_wheel:
     name: Build and upload wheel
     container:
-      image: ghcr.io/oxionics/poetry:1.21
+      image: ghcr.io/oxionics/poetry:1.22-py3.8
     runs-on:
       group: Default
       labels: self-hosted

--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on:
       group: Default
       labels: self-hosted
-    container: ghcr.io/oxionics/poetry:1.21
+    container: ghcr.io/oxionics/poetry:1.22-py3.8
     steps:
       - uses: OxIonics/poetry-preamble@master
         with:

--- a/.github/workflows/test_flake_black.yml
+++ b/.github/workflows/test_flake_black.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on:
       group: Default
       labels: self-hosted
-    container: ghcr.io/oxionics/poetry:1.21
+    container: ghcr.io/oxionics/poetry:1.22-py3.8
     name: Flake8
     steps:
       - uses: OxIonics/poetry-preamble@master
@@ -54,7 +54,7 @@ jobs:
     runs-on:
       group: Default
       labels: self-hosted
-    container: ghcr.io/oxionics/poetry:1.21
+    container: ghcr.io/oxionics/poetry:1.22-py3.8
     name: Formatting check
     steps:
       - uses: OxIonics/poetry-preamble@master


### PR DESCRIPTION
Since version 1.22, our poetry Docker image is built for Python 3.8 and 3.10.
We use the new version to run CI unit tests with both Python version.
However, I did not update the version of the Docker image in other workflows, which don't need to run with multiple Python versions (e.g. running flake or black).
This PR merely updates those version numbers, still using the Python 3.8 flavour of the image.
Migrating all those other workflows from Python 3.8 to 3.10 will be subject of a separate PR.
I have encountered CI failures in ion-transport that can be fixed by using a more recent build of those images, so upgrading to the latest version is needed in those places. Plus - I should really have included these changes in the original PR that introduces Py3.10 tests - we shouldn't use two different versions of those Docker images.
