### PR TITLE
Update actions to latest

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ jobs:
       group: "${{ github.event_name == 'push' && 'ghcr-login' || null }}"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Build image
         run: |

--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -115,7 +115,7 @@ jobs:
       - name: Build wheel
         run: poetry build -f wheel
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.os }}-py${{ matrix.python }}
           path: ./dist/*whl
@@ -130,17 +130,17 @@ jobs:
       group: Default
       labels: self-hosted
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Check if files other than poetry.lock have changed
         id: poetry-lock-changed
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v44
         with:
           files: poetry.lock
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: ./artifacts
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -29,7 +29,7 @@ jobs:
       labels: self-hosted
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -107,7 +107,7 @@ jobs:
           github.event_name == 'push' &&
           steps.poetry-lock-exists.outputs.file_exists == 'true'
         id: poetry-lock-changed
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@v44
         with:
             files: poetry.lock
       - name: Configure poetry


### PR DESCRIPTION
GitHub actions have deprecated Node 16 in favour of Node 20, and so we need to bump a bunch of actions too. This will also require a change in poetry-preamble — am also looking at that.