### PR TITLE
Don't install maturin into the build environment

### DIFF
--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           pipx install poetry==1.6.1
           pipx install poethepoet==0.22.0
-          pipx install maturin==0.13.2
 
       - name: Install Poetry dynamic versioning
         run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.0.1 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}


### PR DESCRIPTION
See https://github.com/OxIonics/qumo/pull/356 — we use maturin installed into the Python build environment, rather than the global one.