### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/common_pre_commit_checks.yml
+++ b/.github/workflows/common_pre_commit_checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on:
       group: Default
       labels: self-hosted
-    container: ghcr.io/oxionics/poetry:1.22-py3.8
+    container: ghcr.io/oxionics/poetry:1.22-py3.10
     name: Common pre-commit checks
     steps:
       - uses: OxIonics/poetry-preamble@master

--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2022, macos-11]
-        python: ["3.8", "3.10"]
+        python: ["3.10"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -124,7 +124,7 @@ jobs:
   upload_wheels:
     needs: build_wheels
     if: github.event_name == 'push'
-    container: ghcr.io/oxionics/poetry:1.22-py3.8
+    container: ghcr.io/oxionics/poetry:1.22-py3.10
     runs-on:
       group: Default
       labels: self-hosted

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -23,7 +23,7 @@ jobs:
   build_and_upload_wheel:
     name: Build and upload wheel
     container:
-      image: ghcr.io/oxionics/poetry:1.22-py3.8
+      image: ghcr.io/oxionics/poetry:1.22-py3.10
     runs-on:
       group: Default
       labels: self-hosted

--- a/.github/workflows/pytype.yml
+++ b/.github/workflows/pytype.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on:
       group: Default
       labels: self-hosted
-    container: ghcr.io/oxionics/poetry:1.22-py3.8
+    container: ghcr.io/oxionics/poetry:1.22-py3.10
     steps:
       - uses: OxIonics/poetry-preamble@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ["3.8", "3.10"]
+        python: ["3.10"]
     runs-on:
       group: Default
       labels: self-hosted

--- a/.github/workflows/test_flake_black.yml
+++ b/.github/workflows/test_flake_black.yml
@@ -19,7 +19,7 @@ jobs:
     if: ${{ inputs.RUN_TESTS }}
     strategy:
       matrix:
-        python: ["3.8", "3.10"]
+        python: ["3.10"]
     runs-on:
       group: Default
       labels: self-hosted
@@ -39,7 +39,7 @@ jobs:
     runs-on:
       group: Default
       labels: self-hosted
-    container: ghcr.io/oxionics/poetry:1.22-py3.8
+    container: ghcr.io/oxionics/poetry:1.22-py3.10
     name: Flake8
     steps:
       - uses: OxIonics/poetry-preamble@master
@@ -54,7 +54,7 @@ jobs:
     runs-on:
       group: Default
       labels: self-hosted
-    container: ghcr.io/oxionics/poetry:1.22-py3.8
+    container: ghcr.io/oxionics/poetry:1.22-py3.10
     name: Formatting check
     steps:
       - uses: OxIonics/poetry-preamble@master


### PR DESCRIPTION
This PR removes the use of Python 3.8 in CI jobs. This includes no longer running unit test with Python 3.8. Also, Python 3.8 will no longer be built. And we're now using Python 3.10 instead of 3.8 for random things like running the Black code formatter.