### PR TITLE
Increase poetry requests timeout for upload

### DIFF
--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -162,3 +162,6 @@ jobs:
           steps.poetry-lock-changed.outcome == 'skipped' ||
           steps.poetry-lock-changed.outputs.only_modified == 'false'
         run: poetry publish -r oxionics
+        env:
+          PIP_REQUESTS_TIMEOUT: 300
+          POETRY_REQUESTS_TIMEOUT: 300

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -128,3 +128,6 @@ jobs:
               steps.poetry-lock-changed.outputs.only_modified == 'false'
           )
         run: poetry publish -r oxionics
+        env:
+          PIP_REQUESTS_TIMEOUT: 300
+          POETRY_REQUESTS_TIMEOUT: 300


### PR DESCRIPTION
Now that we've increased this timeout for poetry installs we occasionally see uploads failing, so increase the timeout for that too.

cc @SquidDev 