### PR TITLE
Remove support for macOS build

### DIFF
--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build wheels for Python ${{ matrix.python }} on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-11]
+        os: [ubuntu-20.04, windows-2022]
         python: ["3.10"]
 
     runs-on: ${{ matrix.os }}
@@ -57,7 +57,6 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-          target: "${{ startsWith(matrix.os, 'macos') && 'aarch64-apple-darwin' || '' }}"
           override: true
 
       - name: Check poetry lock file


### PR DESCRIPTION
macOS 11 which we were using is no longer supported by GHA. We no longer have an macOS relevant users in the company see: https://oxionics.slack.com/archives/C02TBJJNC3U/p1719934553728229