### PR TITLE
Add Python docs build jobs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,37 @@
+on:
+  workflow_call:
+    secrets:
+      GHA_TOKEN:
+        required: true
+
+jobs:
+  build_docs:
+    runs-on: self-hosted
+    container:
+      image: ghcr.io/oxionics/poetry:1.22-py3.10
+
+    steps:
+      - uses: OxIonics/poetry-preamble@master
+        with:
+          GHA_TOKEN: ${{ secrets.GHA_TOKEN }}
+
+      - name: Build docs
+        run: |
+          cd docs
+          poetry run make html
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rendered-docs
+          path: ./docs/_build/html/*
+
+  deploy_docs:
+    if: ${{ github.event_name == 'push' }}
+    needs: build_docs
+    runs-on: self-hosted
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          # Name is required to prevent additional `artifact` directory
+          name: rendered-docs
+          path: ~/docs/${{ github.event.repository.name }}/${{ github.ref_name }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -16,9 +16,7 @@ jobs:
           GHA_TOKEN: ${{ secrets.GHA_TOKEN }}
 
       - name: Build docs
-        run: |
-          cd docs
-          poetry run make html
+        run: poe docs
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/undeploy-docs.yml
+++ b/.github/workflows/undeploy-docs.yml
@@ -1,0 +1,11 @@
+on:
+  workflow_call
+
+jobs:
+  deploy:
+    if: github.event.ref_type == 'branch'
+    name: delete
+    runs-on: self-hosted
+    steps:
+      - name: Delete rendered docs
+        run: rm -r ~/docs/${{ github.event.repository.name }}/${{ github.event.ref }}


### PR DESCRIPTION
Used in `ion-transport`, copied over here. I will have follow-up PRs that use this in a new `base_project` branch that is used by `ion-transport`.