### PR TITLE
Fix broken docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
       # If triggered by a push, we will upload the image to the container
       # registry. Logging in/out of the registry from jobs running in parallel
       # seems to interfere with each other.
-      group: "${{ github.event_name == 'push' && 'ghcr-login' || null }}"
+      group: 'all'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Can't have `null` concurrency group. No need to define a concurrency group for when the trigger isn't push, because we only run job when trigger is push.

https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency