### PR TITLE
Run `poetry install` before `poetry build`

### DIFF
--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Install Poetry dynamic versioning
         run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.0.1 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}
 
+      - name: Install package dependencies
+        run: poetry install
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal


### PR DESCRIPTION
Only needed for package-multiplatform as it's only one that can have custom build.py and so potentially require packages installed.

This is currently causing failures in https://github.com/OxIonics/hermit/pull/9 as a Python script is run as part of `build.py`.