### PR TITLE
Update rust CI

### DIFF
--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -20,7 +20,7 @@ on:
         type: boolean
       RUST_TOOLCHAIN:
         required: false
-        default: "stable"
+        default: ""
         type: string
       RUST_COMPONENTS:
         required: false
@@ -61,9 +61,8 @@ jobs:
       - name: Install Poetry dynamic versioning
         run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.0.1 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}
 
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
         with:
-          profile: minimal
           toolchain: ${{ inputs.RUST_TOOLCHAIN }}
           override: true
           components: ${{ inputs.RUST_COMPONENTS }}

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -7,46 +7,42 @@ on:
         required: false
         default: true
         type: boolean
-      TEST_ARGS:
+      CLIPPY_TOOLCHAIN:
         required: false
         default: ""
         type: string
-      CLIPPY_TOOLCHAIN:
+      FMT_TOOLCHAIN:
         required: false
-        default: stable
-        type: string
-      TEST_TOOLCHAIN:
-        required: false
-        default: stable
-        type: string
-      UBUNTU_VERSION:
-        required: false
-        default: 24.04
+        default: ""
         type: string
 
 jobs:
   fmt:
     name: Rustfmt
-    runs-on: ubuntu-${{ inputs.UBUNTU_VERSION }}
+    container:
+      image: ghcr.io/oxionics/poetry:1.23-py3.10
+    runs-on:
+      group: Default
+      labels: self-hosted
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
         with:
-          toolchain: nightly
+          toolchain: ${{ inputs.FMT_TOOLCHAIN }}
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
-      # TODO consider using https://github.com/mbrobbel/rustfmt-check which
-      #      pushes a commit to fix formatting problems
-      # I've failed to get this to output color even passing --color always to
-      # both cargo and rustfmt.
-      - run: cargo +nightly fmt -- --check
+      - run: poe fmt-test-rs
 
   clippy:
     name: Clippy
-    runs-on: ubuntu-${{ inputs.UBUNTU_VERSION }}
+    container:
+      image: ghcr.io/oxionics/poetry:1.23-py3.10
+    runs-on:
+      group: Default
+      labels: self-hosted
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
         with:
           toolchain: ${{ inputs.CLIPPY_TOOLCHAIN }}
           components: clippy
@@ -60,12 +56,14 @@ jobs:
   test:
     name: Test
     if: ${{ inputs.RUN_TESTS }}
-    runs-on: ubuntu-${{ inputs.UBUNTU_VERSION }}
+    container:
+      image: ghcr.io/oxionics/poetry:1.23-py3.10
+    runs-on:
+      group: Default
+      labels: self-hosted
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ inputs.TEST_TOOLCHAIN }}
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test ${{ inputs.TEST_ARGS }}
+      - run: poe test-rs
         name: Test


### PR DESCRIPTION
## Summary

* Use new `poe` tasks, and consequently use our image that has `poe` etc installed.
* Use an action for setting up rust toolchain that uses the `rust-toolchain.toml` file by default

## Testing
* hermit packaging: https://github.com/OxIonics/hermit/actions/runs/11386398472/job/31678514588
* qumo fmt/test/clippy: https://github.com/OxIonics/qumo/actions/runs/11385405327

## Poe tasks
The idea is the poe tasks in combination rust and python projects like qumo and hermit would be:

```toml
fmt-py = "black ."
fmt-test-py = "black --check ."
test-py = "pytest --snapshot-warn-unused"
test-regen = "pytest --snapshot-update"
flake = "flake8 ."
types = { script = "run_pytype:main" }

fmt-rs="cargo +nightly fmt"
fmt-test-rs="cargo +nightly fmt -- --check"
test-rs="cargo test --no-default-features"
clippy="cargo clippy --tests --all-features -- -D warnings"

fmt = ["fmt-py", "fmt-rs"]
test = ["test-py", "test-rs"]
lint = ["flake", "clippy"]
```

though I'm open to other suggestions.

## Versioning

I've made this a draft because I think the removal of arguments in the `rust-check.yml` should mean we move `common-workflows` to `v3`. It's a shame that some of them are arguments I only recently added. We _could_ keep some of them with not much harm, but the `UBUNTU_VERSION` argument wouldn't be used. And it doesn't seem like that big a deal to update to `v3`, just a shame to do it the day after making other changes to `base_project`.

## See also

* https://oxionics.slack.com/archives/C02TBJJNC3U/p1729093470547249
* https://oxionics.slack.com/archives/C02TBJJNC3U/p1729092556967029?thread_ts=1728991403.023149&cid=C02TBJJNC3U