### PR TITLE
Run all pre-commit hooks in one job

### DIFF
--- a/.github/workflows/common_pre_commit_checks.yml
+++ b/.github/workflows/common_pre_commit_checks.yml
@@ -23,23 +23,10 @@ jobs:
           INSTALL_ARGS: ${{ inputs.INSTALL_ARGS }}
           GHA_TOKEN: ${{ secrets.GHA_TOKEN }}
 
-      - name: Trailing white space
+      - name: Run pre-commit
         run: >-
           poetry run pre-commit run
           --from-ref=${{ github.event.pull_request.base.sha || 'HEAD~1' }}
           --to-ref=HEAD
-          trailing-whitespace
-
-      - name: End of file
-        run: >-
-          poetry run pre-commit run
-          --from-ref=${{ github.event.pull_request.base.sha || 'HEAD~1' }}
-          --to-ref=HEAD
-          end-of-file-fixer
-
-      - name: Check added large files
-        run: >-
-          poetry run pre-commit run
-          --from-ref=${{ github.event.pull_request.base.sha || 'HEAD~1' }}
-          --to-ref=HEAD
-          check-added-large-files
+        env:
+          RUFF_OUTPUT_FORMAT: github


### PR DESCRIPTION
As discussed in https://github.com/OxIonics/base_project/pull/180.

There's a bit of me which wonders if we should just do `pre-commit run --all-files`, rather than on the latest set of changes, just so possible issues don't get lost.