### PR TITLE
Avoid overriding rust compiler flags

### DIFF
--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -66,6 +66,7 @@ jobs:
           toolchain: ${{ inputs.RUST_TOOLCHAIN }}
           override: true
           components: ${{ inputs.RUST_COMPONENTS }}
+          rustflags: ""
 
       - name: Check poetry lock file
         run: poetry lock --check


### PR DESCRIPTION
Fixes https://github.com/OxIonics/hermit/issues/18

The `actions-rust-lang/setup-rust-toolchain` action by default sets the rustflags to `-D warnings` which then overrides anything that you might have set in your `.cargo/config.toml`.

This was causing the hermit build to build with out position-independent code.

Fortunately, if you set the `rustflags` argument to an empty string, that doesn't override the rust flags that are set in the `config.toml`.

I wonder if we should just invoke rustup ourselves instead of relying on existing actions like this. But it's frustrating as in theory they should iron lots of fiddly things rather than creating them with choices like this.