### PR TITLE
Remove rustfmt from rust-check.yml

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -17,22 +17,6 @@ on:
         type: string
 
 jobs:
-  fmt:
-    name: Rustfmt
-    container:
-      image: ghcr.io/oxionics/poetry:1.26-py3.10
-    runs-on:
-      group: Default
-      labels: self-hosted
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
-        with:
-          toolchain: ${{ inputs.FMT_TOOLCHAIN }}
-          components: rustfmt
-      - uses: Swatinem/rust-cache@v2
-      - run: poe fmt-test-rs
-
   clippy:
     name: Clippy
     container:


### PR DESCRIPTION
See https://github.com/OxIonics/base_project/pull/183

We'll run this as part of the pre-commit checks instead, whereas at the moment it is duplicated in some repos.

There's now an unused argument in this workflow, `FMT_TOOLCHAIN`, but I'd prefer not to remove it and trigger a breaking change. I don't think it's harmful to keep it there unused, and I believe we'll get a warning from GHA if it's passed in but not used, though I might have the details wrong there.