### PR TITLE
use `poe lint-rs` to run clippy

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -31,11 +31,7 @@ jobs:
           toolchain: ${{ inputs.CLIPPY_TOOLCHAIN }}
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - uses: giraffate/clippy-action@v1
-        with:
-          reporter: 'github-pr-review'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          clippy_flags: --tests --all-features -- -D warnings
+      - run: poe lint-rs
 
   test:
     name: Test


### PR DESCRIPTION
I was having issues with giraffate/clippy-action failing silently that I couldn't quickly get to the bottom of. In general i think it would be better for us to use less third party actions to avoid such issues. Plus, this way we don't duplicate the clippy flags between `pyproject.toml` and here.

This does assume that rust projects using this will have a `pyproject.toml` with poe tasks defined, which is currently true, and likely to always be true as we use it for the base project configuration.

This requires https://github.com/OxIonics/base_project/pull/195, but the changes from there are merged in all relevant projects.