### PR TITLE
Run clippy directly

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: ""
         type: string
+      CLIPPY_FLAGS:
+        required: false
+        default: "--tests --all-features -- -D warnings"
+        type: string
       FMT_TOOLCHAIN:
         required: false
         default: ""
@@ -31,7 +35,7 @@ jobs:
           toolchain: ${{ inputs.CLIPPY_TOOLCHAIN }}
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: poe lint-rs
+      - run: cargo clippy ${{ inputs.CLIPPY_FLAGS }}
 
   test:
     name: Test


### PR DESCRIPTION
Running with `poe lint-rs` required either creating the poetry project venv first (why, it is unclear) or making `poe lint-rs` a poe shell task.

However, we don't want it to be a shell task because this means you can't pass extra arguments to it.

It seems undesirable to have to run `poetry install` just to run `clippy`, so instead we will just run clippy directly.

See also #76 