### PR TITLE
Switch to Vivado 2024.2

### DIFF
--- a/.github/workflows/build_binaries.yml
+++ b/.github/workflows/build_binaries.yml
@@ -10,7 +10,7 @@ on:
     inputs:
       vivado_version:
         description: 'Version of Vivado to use'
-        default: "2020.1"
+        default: "2024.2"
         type: string
         required: true
       config_module:
@@ -43,11 +43,11 @@ jobs:
 
 
       - name: Install
-        run: poetry install
+        run: poetry install --sync
 
       - name: Build Binaries
         run: |
-          export PATH=${{ secrets.VIVADO_ROOT_DIR }}/${{ inputs.vivado_version || '2020.1' }}/bin/:$PATH
+          export PATH=${{ secrets.VIVADO_ROOT_DIR }}/${{ inputs.vivado_version || '2024.2' }}/bin/:$PATH
           poetry run binary_build \
             --gh-user oxionics \
             --gh-password ${{ secrets.GHA_TOKEN }} \


### PR DESCRIPTION
This matches what upstream uses. AFAIK this default isn't actually used anywhere (we also set the default in base project) — will also change it there.

This also switches the `poetry install` to use `--sync`. It might be possible for us to use Poetry-preamble here. I feel there's a reason we don't use it here, but can't remember why!