### PR TITLE
Rust check features and packages parameters

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -19,6 +19,11 @@ on:
         required: false
         default: ""
         type: string
+      PACKAGES:
+        required: false
+        description: Comma separated list of packages to run against, if empty the default workspace packages will be used
+        default: ""
+        type: string
 
 jobs:
   clippy:
@@ -38,10 +43,17 @@ jobs:
           toolchain: ${{ inputs.CLIPPY_TOOLCHAIN }}
           components: clippy
 
+      - name: Generate Flags
+        run: |
+          if [ ! -z "${{ inputs.PACKAGES }}" ]; then
+            echo PACKAGES=$(echo "${{ inputs.PACKAGES }}" | sed 's/[ ,]/ --package /;s/^/--package /') >> $GITHUB_ENV;
+          fi
+
       - name: Lint with Clippy
         run: >
           cargo clippy
           ${{ inputs.CLIPPY_FLAGS }}
+          ${{ env.PACKAGES }}
 
   test:
     name: Test
@@ -58,5 +70,13 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
 
+      - name: Generate Flags
+        run: |
+          if [ ! -z "${{ inputs.PACKAGES }}" ]; then
+            echo PACKAGES=$(echo "${{ inputs.PACKAGES }}" | sed 's/[ ,]/ --package /;s/^/--package /') >> $GITHUB_ENV;
+          fi
+
       - name: Run Tests
-        run: poe test-rs
+        run: >
+          poe test-rs
+          ${{ env.PACKAGES }}

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -13,7 +13,7 @@ on:
         type: string
       CLIPPY_FLAGS:
         required: false
-        default: "--tests --all-features -- -D warnings"
+        default: "--tests -D warnings"
         type: string
       FMT_TOOLCHAIN:
         required: false
@@ -22,6 +22,11 @@ on:
       PACKAGES:
         required: false
         description: Comma separated list of packages to run against, if empty the default workspace packages will be used
+        default: ""
+        type: string
+      FEATURES:
+        required: false
+        description: Space or comma separated list of features to activate, if empty all features will be activated
         default: ""
         type: string
 
@@ -48,12 +53,18 @@ jobs:
           if [ ! -z "${{ inputs.PACKAGES }}" ]; then
             echo PACKAGES=$(echo "${{ inputs.PACKAGES }}" | sed 's/[ ,]/ --package /;s/^/--package /') >> $GITHUB_ENV;
           fi
+          if [ ! -z "${{ inputs.FEATURES }}" ]; then
+            echo FEATURES=$(echo "${{ inputs.FEATURES }}" | sed 's/^/--features /') >> $GITHUB_ENV;
+          else
+            echo FEATURES="--all-features" >> $GITHUB_ENV;
+          fi
 
       - name: Lint with Clippy
         run: >
           cargo clippy
           ${{ inputs.CLIPPY_FLAGS }}
           ${{ env.PACKAGES }}
+          ${{ env.FEATURES  }}
 
   test:
     name: Test
@@ -75,8 +86,14 @@ jobs:
           if [ ! -z "${{ inputs.PACKAGES }}" ]; then
             echo PACKAGES=$(echo "${{ inputs.PACKAGES }}" | sed 's/[ ,]/ --package /;s/^/--package /') >> $GITHUB_ENV;
           fi
+          if [ ! -z "${{ inputs.FEATURES }}" ]; then
+            echo FEATURES=$(echo "${{ inputs.FEATURES }}" | sed 's/^/--features /') >> $GITHUB_ENV;
+          else
+            echo FEATURES="--all-features" >> $GITHUB_ENV;
+          fi
 
       - name: Run Tests
         run: >
           poe test-rs
           ${{ env.PACKAGES }}
+          ${{ env.FEATURES }}

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -13,7 +13,7 @@ on:
         type: string
       CLIPPY_FLAGS:
         required: false
-        default: "--tests -D warnings"
+        default: "--tests"
         type: string
       FMT_TOOLCHAIN:
         required: false

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           toolchain: ${{ inputs.CLIPPY_TOOLCHAIN }}
           components: clippy
-      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy ${{ inputs.CLIPPY_FLAGS }}
 
   test:
@@ -48,6 +47,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
-      - uses: Swatinem/rust-cache@v2
       - run: poe test-rs
         name: Test

--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -29,12 +29,19 @@ jobs:
       group: Default
       labels: self-hosted
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
+      - name: Checkout Source
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
         with:
           toolchain: ${{ inputs.CLIPPY_TOOLCHAIN }}
           components: clippy
-      - run: cargo clippy ${{ inputs.CLIPPY_FLAGS }}
+
+      - name: Lint with Clippy
+        run: >
+          cargo clippy
+          ${{ inputs.CLIPPY_FLAGS }}
 
   test:
     name: Test
@@ -45,7 +52,11 @@ jobs:
       group: Default
       labels: self-hosted
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
-      - run: poe test-rs
-        name: Test
+      - name: Checkout Source
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
+
+      - name: Run Tests
+        run: poe test-rs


### PR DESCRIPTION
Adds `FEATURES` and `PACKAGES` inputs to the `rust-check` workflow to support the oddities of [`bozu`](https://github.com/OxIonics/bozu/pull/55), also removes the `FMT_TOOLCHAIN` input which was unused (making it a breaking change). Not too happy about duplicating the `Generate Flags` step, but moving it into it's own job felt even worse