### PR TITLE
Switch to new has-changed-files action

### DIFF
--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -141,12 +141,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if files other than poetry.lock have changed
-        id: poetry-lock-changed
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
-        with:
-          files: poetry.lock
-
       - uses: actions/download-artifact@v4
         with:
           path: ./artifacts
@@ -159,6 +153,12 @@ jobs:
       - name: Install Poetry dynamic versioning
         run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.0.1 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}
 
+      - name: Check if files other than poetry.lock have changed
+        id: poetry-lock-changed
+        uses: OxIonics/common-actions/has-changed-files@master
+        with:
+            exclude: poetry.lock
+
       - name: Configure poetry
         run: |
           poetry config repositories.oxionics ${{ secrets.PYPI_SERVER }}
@@ -166,9 +166,7 @@ jobs:
             ${{ secrets.PYPI_LOGIN }} ${{ secrets.PYPI_PASSWORD }}
 
       - name: Upload wheel
-        if: |
-          steps.poetry-lock-changed.outcome == 'skipped' ||
-          steps.poetry-lock-changed.outputs.only_modified == 'false'
+        if:  steps.poetry-lock-changed.outputs.changed == 'true'
         run: poetry publish -r oxionics
         env:
           PIP_REQUESTS_TIMEOUT: 300

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,25 +97,15 @@ jobs:
       - name: Build wheel
         run: poetry build -f wheel
 
-      - id: poetry-lock-exists
-        if: github.event_name == 'push'
-        uses: andstor/file-existence-action@v2
-        with:
-          files: poetry.lock
       - name: Check if files other than poetry.lock have changed
-        if: |
-          github.event_name == 'push' &&
-          steps.poetry-lock-exists.outputs.file_exists == 'true'
         id: poetry-lock-changed
-        uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b
+        uses: OxIonics/common-actions/has-changed-files@master
         with:
-            files: poetry.lock
+            exclude: poetry.lock
+
       - name: Configure poetry
         if: |
-          github.event_name == 'push' && (
-            steps.poetry-lock-changed.outcome == 'skipped' ||
-            steps.poetry-lock-changed.outputs.only_modified == 'false'
-          )
+          github.event_name == 'push' && steps.poetry-lock-changed.outputs.changed == 'true'
         run: |
           poetry config repositories.oxionics ${{ secrets.PYPI_SERVER }}
           poetry config http-basic.oxionics \
@@ -123,10 +113,7 @@ jobs:
 
       - name: Upload wheel
         if: |
-          github.event_name == 'push' && (
-              steps.poetry-lock-changed.outcome == 'skipped' ||
-              steps.poetry-lock-changed.outputs.only_modified == 'false'
-          )
+          github.event_name == 'push' && steps.poetry-lock-changed.outputs.changed == 'true'
         run: poetry publish -r oxionics
         env:
           PIP_REQUESTS_TIMEOUT: 300


### PR DESCRIPTION
[common-actions](https://github.com/OxIonics/common-actions/pull/1) | **common-workflows**

The tj-actions/changed-files was compromised over the weekend. While this has now been resolved, I'd feel much better if we had fewer dependencies on third-party GitHub actions. This replaces the action with home-grown reimplementation of the same.