### PR TITLE
Add argument for ubuntu version to multipackage workflow

### DIFF
--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -26,13 +26,17 @@ on:
         required: false
         default: ""
         type: string
+      UBUNTU_VERSION:
+        required: false
+        default: "20.04"
+        type: string
 
 jobs:
   build_wheels:
     name: Build wheels for Python ${{ matrix.python }} on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022]
+        os: ["ubuntu-${{ inputs.UBUNTU_VERSION }}", windows-2022]
         python: ["3.10"]
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The default shouldn't stay as ubuntu-20.04, but apparently we can't upgrade it yet given many of our systems are still on 20.04, and updating changes the version of glibc linked in. See https://github.com/OxIonics/common-workflows/commit/cce00f624647c79545770d71bd2c98abd1dd8572.

However, some projects don't use glibc so a quick fix for those projects, until we've upgraded the systems on old Ubuntu, is to allow this to be configurable.

Tested here https://github.com/OxIonics/hermit/actions/runs/14357810322