### PR TITLE
Update poetry-dynamic-versioning version

### DIFF
--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -59,11 +59,11 @@ jobs:
 
       - name: Install poetry etc into pipx environment
         run: |
-          pipx install poetry==1.6.1
-          pipx install poethepoet==0.22.0
+          pipx install poetry==2.1.1
+          pipx install poethepoet==0.33.1
 
       - name: Install Poetry dynamic versioning
-        run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.0.1 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}
+        run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.8.2 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
         with:
@@ -73,7 +73,7 @@ jobs:
           rustflags: ""
 
       - name: Check poetry lock file
-        run: poetry lock --check
+        run: poetry check --lock
 
       - name: Check package versions
         if: inputs.CHECK_PACKAGE_VERSION
@@ -161,7 +161,7 @@ jobs:
           mv artifacts/*/* dist
 
       - name: Install Poetry dynamic versioning
-        run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.0.1 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}
+        run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.8.2 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}
 
       - name: Configure poetry
         run: |

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
 
       - name: Install Poetry dynamic versioning
-        run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.0.1 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}
+        run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.8.2 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}
 
       - name: Install additional Python dependencies
         run: pip install tomlkit
@@ -44,7 +44,7 @@ jobs:
         run: rustup default stable
 
       - name: Check poetry lock file
-        run: poetry lock --check
+        run: poetry check --lock
 
       - name: Check package versions
         if: ${{ inputs.CHECK_PACKAGE_VERSION }}


### PR DESCRIPTION
This was silently downgrading us to Poetry 1.x. Hopefully we'll be able to put this in the Package metadata instead, so we don't have to install it in CI.