### PR TITLE
Add softies-review-requests workflow

### DIFF
--- a/.github/workflows/softies-review-request.yml
+++ b/.github/workflows/softies-review-request.yml
@@ -12,4 +12,4 @@ jobs:
         webhook: ${{ secrets.SOFTIES_REVIEW_REQUEST_WEBHOOK_URL }}
         webhook-type: incoming-webhook
         payload: |
-          text: "${{ github.event.pull_request.html_url }}"
+          text: "<${{ github.event.pull_request.html_url }}|${{ github.event.repository.name }}#${{ github.event.pull_request.number }}> ${{ github.event.pull_request.title }}"

--- a/.github/workflows/softies-review-request.yml
+++ b/.github/workflows/softies-review-request.yml
@@ -1,0 +1,15 @@
+on:
+  pull_request:
+    types: [review_requested]
+jobs:
+  softies_review_requested:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.requested_team.name == 'softies'}}
+    steps:
+    - name: "Post a message in #softies-review-requests"
+      uses: slackapi/slack-github-action@v2.0.0
+      with:
+        webhook: ${{ secrets.SOFTIES_REVIEW_REQUEST_WEBHOOK_URL }}
+        webhook-type: incoming-webhook
+        payload: |
+          text: "${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
This adds a workflow to notify us when the softies team has been requested as a reviewer on a PR.
We'll have to use this workflow in each repository for which we want such notifications.