### PR TITLE
Run Linux multi-platform builds on our infrastructure

### DIFF
--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -34,6 +34,9 @@ on:
 jobs:
   build_windows_wheel:
     name: Build wheels for Python ${{ matrix.python }} on Windows
+    strategy:
+      matrix:
+        python: ["3.10"]
     runs-on: windows-2022
     steps:
       - name: Checkout
@@ -81,6 +84,9 @@ jobs:
 
   build_linux_wheel:
     name: Build wheels for Python ${{ matrix.python }} on Linux
+    strategy:
+      matrix:
+        python: ["3.10"]
     container:
       image: ghcr.io/oxionics/poetry:1.30-py${{ matrix.python }}
     runs-on:

--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -32,14 +32,9 @@ on:
         type: string
 
 jobs:
-  build_wheels:
-    name: Build wheels for Python ${{ matrix.python }} on ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: ["ubuntu-${{ inputs.UBUNTU_VERSION }}", windows-2022]
-        python: ["3.10"]
-
-    runs-on: ${{ matrix.os }}
+  build_windows_wheel:
+    name: Build wheels for Python ${{ matrix.python }} on Windows
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,13 +49,49 @@ jobs:
       - name: Install specific pip version
         run: python3 -m pip install --upgrade pip==21.3.1
 
-      - name: Install pipx
-        run: pip install pipx==1.1.0 tomlkit
-
-      - name: Install poetry etc into pipx environment
+      - name: Install Poetry, etc...
         run: |
+          pip install pipx==1.1.0
           pipx install poetry==2.1.1
           pipx install poethepoet==0.33.1
+          pipx inject poetry poetry-dynamic-versioning[plugin]==1.8.2
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
+        with:
+          toolchain: ${{ inputs.RUST_TOOLCHAIN }}
+          override: true
+          components: ${{ inputs.RUST_COMPONENTS }}
+          rustflags: ""
+
+      - name: Check poetry lock file
+        run: poetry check --lock
+
+      - name: Check package versions
+        uses: OxIonics/common-actions/check-poetry-version@jjc/check-poetry-version
+
+      - name: Build wheel
+        run: poetry build -f wheel
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheel-windows-py${{ matrix.python }}
+          path: ./dist/*whl
+          if-no-files-found: error
+          retention-days: 1
+
+  build_linux_wheel:
+    name: Build wheels for Python ${{ matrix.python }} on Linux
+    container:
+      image: ghcr.io/oxionics/poetry:1.30-py${{ matrix.python }}
+    runs-on:
+      group: Default
+      labels: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
       - name: Install Poetry dynamic versioning
         run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.8.2 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}
@@ -76,59 +107,14 @@ jobs:
         run: poetry check --lock
 
       - name: Check package versions
-        if: inputs.CHECK_PACKAGE_VERSION
-        shell: python
-        run: |
-          import os
-          import subprocess
-          import sys
-          from typing import NoReturn
-          import tomlkit
-          from packaging.version import Version
-
-
-          def run_command(*cmd) -> str:
-              return subprocess.check_output(cmd, encoding="utf-8").strip()
-
-
-          def gh_command(kind: str, msg: str):
-              print(f"::{kind}::{msg}" if "CI" in os.environ else msg)
-
-
-          def fail_with(msg: str) -> NoReturn:
-              gh_command("error", msg)
-              sys.exit(1)
-
-
-          with open("pyproject.toml", "r") as h:
-              project = tomlkit.load(h)
-              projectVersion = Version(project["tool"]["poetry"]["version"])
-
-          actualVersion = Version(run_command("poetry", "version", "-s"))
-
-          if projectVersion == actualVersion:
-              gh_command("warning", "poetry-dynamic-versioning is not set up on this repo")
-          elif projectVersion.release[0:2] != actualVersion.release[0:2]:
-              # Only compare the major and minor version.
-              fail_with(
-                  f"Version in pyproject.toml ({projectVersion}) does not match "
-                  f"git-derived version ({actualVersion}).",
-              )
-
-          if os.path.isfile("setup.py"):
-              setupVersion = Version(run_command("python", "setup.py", "--version"))
-              if setupVersion.base_version != str(projectVersion):
-                  fail_with(
-                      f"Version in pyproject.toml ({projectVersion}) and setup.py "
-                      f"({setupVersion}) do not match.",
-                  )
+        uses: OxIonics/common-actions/check-poetry-version@jjc/check-poetry-version
 
       - name: Build wheel
         run: poetry build -f wheel
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheel-${{ matrix.os }}-py${{ matrix.python }}
+          name: wheel-linux-py${{ matrix.python }}
           path: ./dist/*whl
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -120,7 +120,7 @@ jobs:
           retention-days: 1
 
   upload_wheels:
-    needs: build_wheels
+    needs: [build_linux_wheel, build_windows_wheel]
     if: github.event_name == 'push'
     container: ghcr.io/oxionics/poetry:1.30-py3.10
     runs-on:

--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -70,7 +70,7 @@ jobs:
         run: poetry check --lock
 
       - name: Check package versions
-        uses: OxIonics/common-actions/check-poetry-version@jjc/check-poetry-version
+        uses: OxIonics/common-actions/check-poetry-version@master
 
       # This job runs outside of the VPN, so doesn't have access to our devpi server.
       # Just remove the source for now.
@@ -118,7 +118,7 @@ jobs:
         run: poetry check --lock
 
       - name: Check package versions
-        uses: OxIonics/common-actions/check-poetry-version@jjc/check-poetry-version
+        uses: OxIonics/common-actions/check-poetry-version@master
 
       - name: Build wheel
         run: poetry build -f wheel

--- a/.github/workflows/package-multiplatform.yml
+++ b/.github/workflows/package-multiplatform.yml
@@ -72,6 +72,11 @@ jobs:
       - name: Check package versions
         uses: OxIonics/common-actions/check-poetry-version@jjc/check-poetry-version
 
+      # This job runs outside of the VPN, so doesn't have access to our devpi server.
+      # Just remove the source for now.
+      - name: Remove OxIonics source
+        run: poetry source remove oxionics
+
       - name: Build wheel
         run: poetry build -f wheel
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -44,7 +44,7 @@ jobs:
         run: poetry check --lock
 
       - name: Check package versions
-        uses: OxIonics/common-actions/check-poetry-version@jjc/check-poetry-version
+        uses: OxIonics/common-actions/check-poetry-version@master
 
       - name: Build wheel
         run: poetry build -f wheel

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Install Poetry dynamic versioning
         run: pipx inject poetry poetry-dynamic-versioning[plugin]==1.8.2 ${{ inputs.EXTRA_POETRY_INJECT_ARGS }}
 
-      - name: Install additional Python dependencies
-        run: pip install tomlkit
-
       - name: Set default Rust toolchain
         run: rustup default stable
 
@@ -47,52 +44,7 @@ jobs:
         run: poetry check --lock
 
       - name: Check package versions
-        if: ${{ inputs.CHECK_PACKAGE_VERSION }}
-        shell: python
-        run: |
-          import os
-          import subprocess
-          import sys
-          from typing import NoReturn
-          import tomlkit
-          from packaging.version import Version
-
-
-          def run_command(*cmd) -> str:
-              return subprocess.check_output(cmd, encoding="utf-8").strip()
-
-
-          def gh_command(kind: str, msg: str):
-              print(f"::{kind}::{msg}" if "CI" in os.environ else msg)
-
-
-          def fail_with(msg: str) -> NoReturn:
-              gh_command("error", msg)
-              sys.exit(1)
-
-
-          with open("pyproject.toml", "r") as h:
-              project = tomlkit.load(h)
-              projectVersion = Version(project["tool"]["poetry"]["version"])
-
-          actualVersion = Version(run_command("poetry", "version", "-s"))
-
-          if projectVersion == actualVersion:
-              gh_command("warning", "poetry-dynamic-versioning is not set up on this repo")
-          elif projectVersion.release[0:2] != actualVersion.release[0:2]:
-              # Only compare the major and minor version.
-              fail_with(
-                  f"Version in pyproject.toml ({projectVersion}) does not match "
-                  f"git-derived version ({actualVersion}).",
-              )
-
-          if os.path.isfile("setup.py"):
-              setupVersion = Version(run_command("python", "setup.py", "--version"))
-              if setupVersion.base_version != str(projectVersion):
-                  fail_with(
-                      f"Version in pyproject.toml ({projectVersion}) and setup.py "
-                      f"({setupVersion}) do not match.",
-                  )
+        uses: OxIonics/common-actions/check-poetry-version@jjc/check-poetry-version
 
       - name: Build wheel
         run: poetry build -f wheel


### PR DESCRIPTION
Requires https://github.com/OxIonics/common-actions/pull/2

 - Switch package/package-multiplatform to use https://github.com/OxIonics/common-actions/pull/2, rather than embedding Python to check package versions.
 - Split package-multiplatform into a Linux build (which runs on our infrastructure, in our docker container) and a Windows one (which runs on GH hosted runners).
 - The Windows job now also removes the OxIonics repository source, to work around https://github.com/python-poetry/poetry/commit/bc2e133f59d832cc2c00184a07babe7eccbdc89e.