### PR TITLE
Add 3.12 to Python version matrix for GitHub test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,11 @@ jobs:
   test:
     strategy:
       matrix:
-        python: ["3.10"]
+        python: ["3.10", "3.12"]
     runs-on:
       group: Default
       labels: self-hosted
-    container: ghcr.io/oxionics/poetry:1.30-py${{ matrix.python }}
+    container: ghcr.io/oxionics/poetry:1.31-py${{ matrix.python }}
     name: Unit Tests (Python ${{ matrix.python }})
     steps:
       - uses: OxIonics/poetry-preamble@master


### PR DESCRIPTION
For https://github.com/OxIonics/ion-experiments/issues/2703.