### PR TITLE
Pin container jobs to Docker-capable builders (vivado label)

### DIFF
--- a/.github/workflows/common_pre_commit_checks.yml
+++ b/.github/workflows/common_pre_commit_checks.yml
@@ -14,7 +14,9 @@ jobs:
   check:
     runs-on:
       group: Default
-      labels: self-hosted
+      # vivado = the Docker-capable builders; excludes the Docker-less deploy
+      # runners that share the Default group. Temporary until they're regrouped.
+      labels: [self-hosted, vivado]
     container: ghcr.io/oxionics/poetry:1.33-py3.12
     name: Common pre-commit checks
     steps:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -47,7 +47,9 @@ jobs:
       image: ghcr.io/oxionics/poetry:1.33-py3.10
     runs-on:
       group: Default
-      labels: self-hosted
+      # vivado = the Docker-capable builders; excludes the Docker-less deploy
+      # runners that share the Default group. Temporary until they're regrouped.
+      labels: [self-hosted, vivado]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,9 @@ jobs:
         python: ["3.10", "3.12"]
     runs-on:
       group: Default
-      labels: self-hosted
+      # vivado = the Docker-capable builders; excludes the Docker-less deploy
+      # runners that share the Default group. Temporary until they're regrouped.
+      labels: [self-hosted, vivado]
     container: ghcr.io/oxionics/poetry:1.33-py${{ matrix.python }}
     name: Unit Tests (Python ${{ matrix.python }})
     steps:


### PR DESCRIPTION
The container jobs in package.yml, common_pre_commit_checks.yml and test.yml run on {group: Default, labels: self-hosted}. The org "Default" group contains both the Docker-capable builders (buildbot-1..15, labelled vivado) and the Docker-less deploy runners (buildbot-deploy-1/2, containerized Podman, no daemon). When a container job lands on a deploy runner it dies at setup ("failed to connect to the docker API /var/run/docker.sock"). This is an intermittent, pre-existing flake that has hit fork CI (misoc#42 pre-commit, m-labs-asyncserial#26 build).

Fix: add the `vivado` label so these jobs only match the Docker-capable builders. Applied on v5 only (blast radius = v5 consumers, i.e. the fork PRs). Note `vivado` is being used as a proxy for "Docker-capable" - the cleaner long-term fix is to move the deploy runners into their own runner group (drafted separately), after which this label can be reverted.

Follow-up: the fork PRs that use common_pre_commit_checks/test at @v4 (migen#29, misoc#42) should bump those pins to @v5 to pick up this fix without touching v4.