### PR TITLE
feat: add jira review request webhook workflow

### DIFF
--- a/.github/workflows/jira-review-webhook.yml
+++ b/.github/workflows/jira-review-webhook.yml
@@ -1,0 +1,23 @@
+on:
+  workflow_call:
+    inputs:
+      team_slug:
+        description: "GitHub team slug that should trigger the Jira sync when requested as a PR reviewer"
+        required: true
+        type: string
+    secrets:
+      JIRA_WEBHOOK_URL:
+        required: true
+
+jobs:
+  forward-to-jira:
+    if: github.event.requested_team.slug == inputs.team_slug
+    runs-on: ubuntu-latest
+    steps:
+      - name: Forward review request to Jira
+        env:
+          JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL }}
+        run: |
+          curl -sf -X POST "$JIRA_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            --data @"$GITHUB_EVENT_PATH"


### PR DESCRIPTION
## TL;DR

Adds a reusable workflow that forwards PR `review_requested` events to a
Jira automation webhook, filtered by team slug. Backwards-compatible
addition to v4 — no existing workflows touched.

## Why

The DV Jira automation (create a review story when `software-devops` is
requested on a PR) broke: the org-level GitHub webhook returned 400
"Missing token" on every delivery after the rule's token was regenerated
and the webhook URL went stale ([DV-440](https://internal.jira.oxionics.com/browse/DV-440)).

The old setup also fired on every `pull_request` action and leaned solely
on a Jira-side condition to filter — fragile, and wasteful of Jira
automation execution quota.

## What

A reusable workflow (`jira-review-webhook.yml`):

- **Filters** by `team_slug` input — only forwards when the requested team
  matches.
- **Forwards** the raw GitHub event payload to the Jira webhook URL
  (`JIRA_WEBHOOK_URL` secret).

## Notes for adopters

This forwards the event only — it provisions nothing Jira-side. Each team
wanting this pattern needs its own Jira automation rule (incoming webhook
trigger + create-issue action, project/issue type configured), its own
secret holding that rule's webhook URL, and a caller workflow passing
their own `team_slug`.

## Related

- [DV-440](https://internal.jira.oxionics.com/browse/DV-440)
- Consumer: OxIonics/ionics after [PR #5751](https://github.com/OxIonics/ionics/pull/5751) merge
