### PR TITLE
fix: authenticate and harden jira review webhook

### DIFF
--- a/.github/workflows/jira-review-webhook.yml
+++ b/.github/workflows/jira-review-webhook.yml
@@ -9,7 +9,8 @@ on:
       JIRA_WEBHOOK_URL:
         required: true
       JIRA_WEBHOOK_TOKEN:
-        required: true
+        # Required only for authenticated webhooks. Sent as a header when set.
+        required: false
 
 # No GITHUB_TOKEN access needed — this only forwards the event to Jira.
 permissions: {}
@@ -24,8 +25,14 @@ jobs:
           JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL }}
           JIRA_WEBHOOK_TOKEN: ${{ secrets.JIRA_WEBHOOK_TOKEN }}
         run: |
+          # Only send the auth header when a token is configured — supports
+          # both authenticated and unauthenticated Jira webhooks.
+          auth_header=()
+          if [ -n "$JIRA_WEBHOOK_TOKEN" ]; then
+            auth_header=(-H "X-Automation-Webhook-Token: $JIRA_WEBHOOK_TOKEN")
+          fi
           curl -sS --fail-with-body -X POST "$JIRA_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -H "X-Automation-Webhook-Token: $JIRA_WEBHOOK_TOKEN" \
+            "${auth_header[@]}" \
             --data @"$GITHUB_EVENT_PATH" \
             -w '\nHTTP %{http_code}\n'

--- a/.github/workflows/jira-review-webhook.yml
+++ b/.github/workflows/jira-review-webhook.yml
@@ -8,6 +8,8 @@ on:
     secrets:
       JIRA_WEBHOOK_URL:
         required: true
+      JIRA_WEBHOOK_TOKEN:
+        required: true
 
 # No GITHUB_TOKEN access needed — this only forwards the event to Jira.
 permissions: {}
@@ -20,8 +22,10 @@ jobs:
       - name: Forward review request to Jira
         env:
           JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL }}
+          JIRA_WEBHOOK_TOKEN: ${{ secrets.JIRA_WEBHOOK_TOKEN }}
         run: |
           curl -sS --fail-with-body -X POST "$JIRA_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
+            -H "X-Automation-Webhook-Token: $JIRA_WEBHOOK_TOKEN" \
             --data @"$GITHUB_EVENT_PATH" \
             -w '\nHTTP %{http_code}\n'

--- a/.github/workflows/jira-review-webhook.yml
+++ b/.github/workflows/jira-review-webhook.yml
@@ -21,6 +21,7 @@ jobs:
         env:
           JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL }}
         run: |
-          curl -sf -X POST "$JIRA_WEBHOOK_URL" \
+          curl -sS --fail-with-body -X POST "$JIRA_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            --data @"$GITHUB_EVENT_PATH"
+            --data @"$GITHUB_EVENT_PATH" \
+            -w '\nHTTP %{http_code}\n'

--- a/.github/workflows/jira-review-webhook.yml
+++ b/.github/workflows/jira-review-webhook.yml
@@ -9,6 +9,9 @@ on:
       JIRA_WEBHOOK_URL:
         required: true
 
+# No GITHUB_TOKEN access needed — this only forwards the event to Jira.
+permissions: {}
+
 jobs:
   forward-to-jira:
     if: github.event.requested_team.slug == inputs.team_slug


### PR DESCRIPTION
## TL;DR

Makes the `jira-review-webhook` reusable workflow actually work: adds
optional token auth, surfaces error responses, and locks down
`GITHUB_TOKEN`. The version merged in OxIonics/common-workflows#98
returned 400 on every call because it sent no authentication.

## Why

The Atlassian automation incoming webhook (`api-private.atlassian.com`)
rejects unauthenticated POSTs with `400 "Missing token"`. The webhook
exposes a URL **and** a separate secret; the secret must be sent as the
`X-Automation-Webhook-Token` header. OxIonics/common-workflows#98 sent
only the URL, so every delivery failed (DV-440).

The original `curl -sf` also hid the response body, so failures showed
up only as opaque `exit code 22` with no reason.

## What

Three changes to `.github/workflows/jira-review-webhook.yml`:

- **Auth** — new optional `JIRA_WEBHOOK_TOKEN` secret, sent as the
  `X-Automation-Webhook-Token` header only when set. Supports both
  authenticated and unauthenticated webhooks.
- **Diagnosability** — swap `curl -sf` for `--fail-with-body` plus an
  HTTP status line, so a rejected POST prints Jira's error inline.
- **Least privilege** — add `permissions: {}` (the job only runs curl;
  no `GITHUB_TOKEN` access needed). Also clears a CodeQL finding on the
  downstream caller.

## Adopting this workflow

Each consuming repo/team needs, per team:

- A Jira automation rule (incoming webhook trigger + create-issue action,
  project/issue type configured).
- Repo secrets: the webhook URL, plus the webhook token if the rule's
  webhook requires authentication.
- A caller job passing `team_slug` + secrets. Multiple teams in one repo
  = one job each (unique job key per team); the reusable workflow's
  `if: requested_team.slug == team_slug` ensures only the matching team's
  job proceeds.

## Notes

- Backwards-compatible additions to `v4` — no new version branch needed
  (per README versioning rules). The token secret is optional, so
  existing callers are unaffected.

## Related

- DV-440
- Follows OxIonics/common-workflows#98 (added the initial workflow)
- Consumer: OxIonics/ionics#5751
