### PR TITLE
Make GAR publish step POSIX-sh compatible

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -140,11 +140,13 @@ jobs:
           GAR_UPLOAD_URL: https://europe-west2-python.pkg.dev/ionics-shared/pypi-internal/
           GAR_READ_URL: https://europe-west2-python.pkg.dev/ionics-shared/pypi
           GAR_TOKEN: ${{ steps.gar-auth.outputs.access_token }}
+        # POSIX sh, not bash: the poetry job container has no bash, so the
+        # runner executes run steps with `sh -e`.
         run: |
-          set -euo pipefail
+          set -eu
           python3 -m pip install --quiet --disable-pip-version-check twine
-          shopt -s nullglob
           for whl in dist/*.whl; do
+            [ -e "$whl" ] || continue
             base="$(basename "$whl")"
             echo "::group::GAR publish ${base}"
             set +e


### PR DESCRIPTION
The GAR dual-publish step added in v5 fails in the poetry job container with:

```
sh: 1: set: Illegal option -o pipefail
```

The container has no bash, so the runner executes run steps with `sh -e`, and both `set -o pipefail` and `shopt -s nullglob` are bashisms. First observed on the m-labs-asyncserial master publish (WIF auth succeeded, step died on line 1).

Fix: `set -eu` (the only pipe feeds an `if` condition, pipefail added nothing) and an `[ -e ] || continue` guard replacing nullglob. Remainder of the script is already POSIX-clean.